### PR TITLE
Show the error message if the OAuth failed

### DIFF
--- a/callback.php
+++ b/callback.php
@@ -22,6 +22,11 @@ function processCode()
     $OAuth2LoginHelper = $dataService->getOAuth2LoginHelper();
     $parseUrl = parseAuthRedirectUrl($_SERVER['QUERY_STRING']);
 
+    if(isset($parseUrl['error'])) {
+        echo 'Error: ' . $parseUrl['error'];
+        return;
+    }
+
     /*
      * Update the OAuth2Token
      */
@@ -38,6 +43,7 @@ function parseAuthRedirectUrl($url)
 {
     parse_str($url,$qsArray);
     return array(
+        'error' => $qsArray['error'],
         'code' => $qsArray['code'],
         'realmId' => $qsArray['realmId']
     );


### PR DESCRIPTION
If the Connect to QuickBooks flow failed, this shows the error message received on the page so that the user can be alerted to fix the problem. Before this change, the callback page ignored the error and attempted to get a token anyway, resulting in a confusing PHP error message (see #2).

TIP: Click Cancel in the pop-up login window after clicking "Connect to QuickBooks" in the index page to see this new functionality in action.