### PR TITLE
Fix $_SERVER['QUERY_STRING']

### DIFF
--- a/callback.php
+++ b/callback.php
@@ -20,7 +20,7 @@ function processCode()
     ));
 
     $OAuth2LoginHelper = $dataService->getOAuth2LoginHelper();
-    $parseUrl = parseAuthRedirectUrl($_SERVER['QUERY_STRING']);
+    $parseUrl = parseAuthRedirectUrl(htmlspecialchars_decode($_SERVER['QUERY_STRING']));
 
     /*
      * Update the OAuth2Token


### PR DESCRIPTION
Fix `$_SERVER['QUERY_STRING']` to return `realmId` on `parseAuthRedirectUrl($url)`.

`&amp;` on URL is not working with `parse_str` and returned only `code` on function.