### PR TITLE
change the composer property name

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "intuit-demos-webhooks",
+  "name": "intuitdeveloper/helloworld-php",
   "description": "A sample PHP Hello Application to demonstrate OAuth2.0",
   "type": "library",
   "keywords": ["api", "http", "rest", "quickbooks", "smallbusiness"],


### PR DESCRIPTION
Hi, Devs!

I was facing the issue while running `composer i`: 
![Screenshot from 2022-01-06 18-52-44](https://user-images.githubusercontent.com/27553502/148394732-0c340f1c-7d1f-416f-824a-5daf299e504a.png)

Therefore, I just did the naming as according to the [naming scheme](https://getcomposer.org/doc/04-schema.md#name).

TC