### PR TITLE
Fix typo in config.php

### DIFF
--- a/config.php
+++ b/config.php
@@ -2,7 +2,7 @@
 return array(
     'authorizationRequestUrl' => 'https://appcenter.intuit.com/connect/oauth2',
     'tokenEndPointUrl' => 'https://oauth.platform.intuit.com/oauth2/v1/tokens/bearer',
-    'client_id' => 'Enter the clietID from Developer Portal',
+    'client_id' => 'Enter the clientID from Developer Portal',
     'client_secret' => 'Enter the clientSecret from Developer Portal',
     'oauth_scope' => 'com.intuit.quickbooks.accounting openid profile email phone address',
     'oauth_redirect_uri' => 'http://localhost:3000/callback.php',


### PR DESCRIPTION
Fixed a small typo in the config file.

The same typo can also be seen [in the documentation](https://developer.intuit.com/app/developer/qbo/docs/get-started/build-your-first-app#:~:text=client_id%27%20%3D%3E%20%27Enter%20the-,clietID,-from%20Developer%20Portal):
![image](https://github.com/IntuitDeveloper/HelloWorld-PHP/assets/35468343/661ccbf5-a329-4315-bf9c-3d48cfba86ec)

